### PR TITLE
Fix bug with extra hover action on non-hover devices

### DIFF
--- a/src/app/game/game.module.scss
+++ b/src/app/game/game.module.scss
@@ -48,14 +48,26 @@
   margin-left: -0.5rem;
 }
 
-.hand > .selected,
-.hand > button:hover {
-  animation-duration: 0.2s;
-  animation-fill-mode: forwards;
-  animation-iteration-count: 1;
-  animation-name: showHandCard;
-  margin-right: 0.4rem;
-  margin-left: 0.4rem;
+@media (hover: hover) {
+  .hand > button:hover {
+    animation-duration: 0.2s;
+    animation-fill-mode: forwards;
+    animation-iteration-count: 1;
+    animation-name: showHandCard;
+    margin-right: 0.4rem;
+    margin-left: 0.4rem;
+  }
+}
+
+@media (hover: none) {
+  .hand > .selected {
+    animation-duration: 0.2s;
+    animation-fill-mode: forwards;
+    animation-iteration-count: 1;
+    animation-name: showHandCard;
+    margin-right: 0.4rem;
+    margin-left: 0.4rem;
+  }
 }
 @keyframes showHandCard {
   0% {


### PR DESCRIPTION
On mobile, the hover state for the hand cards was triggering along with the normal "selected" class. This should stop that